### PR TITLE
Use copy instead of xcopy on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Rex-Hook-File-Impostor
  [API CHANGES]
 
  [BUG FIXES]
+ - Use copy instead of xcopy on Windows
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Hook/File/Impostor.pm
+++ b/lib/Rex/Hook/File/Impostor.pm
@@ -24,7 +24,7 @@ sub copy_file {
 
     if ( is_windows() ) {
         my $exec = Rex::Interface::Exec->create;
-        $exec->exec("xcopy $original_file $impostor_file");
+        $exec->exec("copy /v /y $original_file $impostor_file");
     }
     else {
         cp $original_file, $impostor_file;


### PR DESCRIPTION
This PR attempts to fix #2 by avoiding any prompts upon file copy operations on Windows.